### PR TITLE
Fixed named export not found, updated GettersTree to _GettersTree

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { PiniaPluginContext, Store, SubscriptionCallbackMutation } from 'pinia'
 import { computed, ComputedRef, reactive } from 'vue'
-import lzutf8 from 'lzutf8';
-const { compress, decompress } = lzutf8;
+import lzutf8 from 'lzutf8'
+const { compress, decompress } = lzutf8
 
 declare module 'pinia' {
   export interface DefineStoreOptionsBase<S, Store> {
@@ -45,11 +45,11 @@ declare module 'pinia' {
   ): H extends false
     ? StoreDefinition<Id, StoreState<SS>, StoreGetters<SS>, StoreActions<SS>>
     : StoreDefinition<
-      Id,
-      StoreState<SS>,
-      StoreGetters<SS> & HistoryPluginGetters,
-      StoreActions<SS> & HistoryPluginActions
-    >
+        Id,
+        StoreState<SS>,
+        StoreGetters<SS> & HistoryPluginGetters,
+        StoreActions<SS> & HistoryPluginActions
+      >
 }
 
 export interface HistoryPluginOptions {
@@ -81,8 +81,8 @@ export interface History extends HistoryPluginOptions {
 
 export interface HistoryStore
   extends Store,
-  HistoryPluginGetters,
-  HistoryPluginActions { }
+    HistoryPluginGetters,
+    HistoryPluginActions {}
 
 /**
  * Base options for the history.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { PiniaPluginContext, Store, SubscriptionCallbackMutation } from 'pinia'
 import { computed, ComputedRef, reactive } from 'vue'
-import { compress, decompress } from 'lzutf8'
+import lzutf8 from 'lzutf8';
+const { compress, decompress } = lzutf8;
 
 declare module 'pinia' {
   export interface DefineStoreOptionsBase<S, Store> {
@@ -44,11 +45,11 @@ declare module 'pinia' {
   ): H extends false
     ? StoreDefinition<Id, StoreState<SS>, StoreGetters<SS>, StoreActions<SS>>
     : StoreDefinition<
-        Id,
-        StoreState<SS>,
-        StoreGetters<SS> & HistoryPluginGetters,
-        StoreActions<SS> & HistoryPluginActions
-      >
+      Id,
+      StoreState<SS>,
+      StoreGetters<SS> & HistoryPluginGetters,
+      StoreActions<SS> & HistoryPluginActions
+    >
 }
 
 export interface HistoryPluginOptions {
@@ -80,8 +81,8 @@ export interface History extends HistoryPluginOptions {
 
 export interface HistoryStore
   extends Store,
-    HistoryPluginGetters,
-    HistoryPluginActions {}
+  HistoryPluginGetters,
+  HistoryPluginActions { }
 
 /**
  * Base options for the history.

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ declare module 'pinia' {
   export function defineStore<
     Id extends string,
     S extends StateTree = {},
-    G extends GettersTree<S> = {},
+    G extends _GettersTree<S> = {},
     A = {},
     H = false
   >(
@@ -24,7 +24,7 @@ declare module 'pinia' {
   export function defineStore<
     Id extends string,
     S extends StateTree = {},
-    G extends GettersTree<S> = {},
+    G extends _GettersTree<S> = {},
     A = {},
     H = false
   >(


### PR DESCRIPTION
This should fix #2. 
I was getting build errors regarding GettersTree, so i updated it to [_GettersTree](https://pinia.vuejs.org/api/modules/pinia.html#getterstree) which seemed to get rid of the error. However, when running the tests it said a test file was missing and i've been unable to test this myself. Would it be possible for you to run tests on this?